### PR TITLE
fixes #18 container parents were not always properly determined

### DIFF
--- a/shipwright/__init__.py
+++ b/shipwright/__init__.py
@@ -72,7 +72,6 @@ class Shipwright(object):
 
 
   def build(self, specifiers):
-    
     tree = dependencies.eval(specifiers, self.targets())
     return self.build_tree(tree)
 

--- a/shipwright/container.py
+++ b/shipwright/container.py
@@ -50,7 +50,7 @@ def containers(name_func, path):
   ]
 
 
-#namespace -> path -> Container(name, path, parent)
+# (path -> name) -> path -> Container(name, path, parent)
 def container_from_path(name_func, path):
   """
   Given a path to a Dockerfile parse the file and return 

--- a/shipwright/version.py
+++ b/shipwright/version.py
@@ -1,1 +1,1 @@
-version = "0.2.2"
+version = "0.2.3"


### PR DESCRIPTION
The order in which images were found via os.walk is not guaranteed. This sometime caused shipwright to think images had no parents. 

This fix looks for images children that may have previously been discovered and reroots them.