### PR TITLE
Uses docker api version 1.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docker-py>=0.6.0
+docker-py>=1.6.0
 requests>=2.4.3
 GitPython==0.3.2.RC1
 zipper

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'docopt',
         'zipper',
         'requests>=2.4.0',
-        'docker-py>=0.6.0',
+        'docker-py>=1.6.0',
         'GitPython==0.3.2.RC1',
         'splicer>=0.2.0'
     ],

--- a/shipwright/cli.py
+++ b/shipwright/cli.py
@@ -159,7 +159,7 @@ def main():
     client_cfg.get('tls')
   )
 
-  client = docker.Client(version='1.15', **client_cfg)
+  client = docker.Client(version='1.18', **client_cfg)
   commands = ['build','push', 'purge']
   # {'publish': false, 'purge': true, ...} = 'purge'
   command_name = _0([

--- a/shipwright/version.py
+++ b/shipwright/version.py
@@ -1,1 +1,1 @@
-version = "0.2.3"
+version = "0.3.0"


### PR DESCRIPTION
Dockerhub is deprecating support for  docker 1.5 so upping requirements to use latest docker-py and at least api 1.18 (same used by docker 1.6)