### PR TITLE
Handle when images depend on parents with "-" or "." in their name.

### DIFF
--- a/shipwright/tar.py
+++ b/shipwright/tar.py
@@ -133,7 +133,7 @@ def tag_parent(tag, docker_content):
   """
 
   v = re.sub(
-    '^(\s*from\s+)(([\w.]+(\:\d+)?\/)?\w+/\w+)(\s*)$', 
+    '^(\s*from\s+)(([\w.-]+(\:\d+)?\/)?[\w.-]+/[\w.-]+)(\s*)$',
     "\\1\\2:" + tag + "\\5", 
     docker_content, 
     flags=re.MULTILINE+re.I


### PR DESCRIPTION
Fix for Issue #40.