### PR TITLE
Clean up non-file configuration

### DIFF
--- a/shipwright/cli.py
+++ b/shipwright/cli.py
@@ -176,12 +176,12 @@ def process_arguments(path, arguments, client_cfg, environ):
         config = json.load(open(
             os.path.join(path, '.shipwright.json'),
         ))
-    except IOError:
+    except EnvironmentError:
         config = {
             'namespace': (
-                arguments['--account'] or
-                environ.get('SW_NAMESPACE')
-            ),
+                arguments.get('DOCKER_HUB_ACCOUNT', None) or
+                os.environ.get('SW_NAMESPACE', None)
+            )
         }
     if config['namespace'] is None:
         exit(


### PR DESCRIPTION
A couple CLI options are currently broken. I do not want to use `.shipwright.json` (need to maintain multiple namespaces) but the `IOError` that is thrown when the file doesn't exist is not caught. I also can't use `SW_NAMESPACE` because I haven't set `DOCKER_HUB_USERNAME`.

So here I catch `OSError` and `IOError` via `EnvironmentError` when attempting to read `.shipwright.json`. I also get `DOCKER_HUB_USERNAME` or `SW_NAMESPACE` with `None` defaults.