### PR TITLE
More efficient required build detection.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ------------------
 
 - Isolate all git functionality, so as to create pluggable Source Control wrappers.
+- More efficient required build detection. (`Issue #18 <https://github.com/shipwright/dockhand/pull/63>`_)
 
 
 0.3.2 (2016-06-06)

--- a/shipwright/base.py
+++ b/shipwright/base.py
@@ -10,44 +10,15 @@ class Shipwright(object):
         self.tags = tags
 
     def targets(self):
-        return self.source_control.targets(self.docker_client)
+        return self.source_control.targets()
 
     def build(self, specifiers):
         tree = dependencies.eval(specifiers, self.targets())
-        info = self._get_build_info(tree)
-        return self.build_tree(tree, info)
-
-    def _get_build_info(self, tree):
+        targets = dependencies.brood(tree)
         this_ref_str = self.source_control.this_ref_str()
-        current, targets = dependencies.needs_building(tree)
+        return self._build(this_ref_str, targets)
 
-        extra = [t._replace(last_built_ref=this_ref_str) for t in targets]
-
-        return {
-            'this_ref_str': this_ref_str,
-            'current': current,
-            'all_images': current + extra,
-            'targets': targets,
-        }
-
-    def build_tree(self, tree, info):
-        current = info['current']
-        this_ref_str = info['this_ref_str']
-        targets = info['targets']
-        all_images = info['all_images']
-
-        for c in current:
-            # these containers weren't effected by the latest changes
-            # so we'll fast forward tag them with the build id. That way  any
-            # of the containers that do need to be built can refer
-            # to the skiped ones by user/image:<last_built_ref> which makes
-            # them part of the same group.
-            yield docker.tag_container(
-                self.docker_client,
-                c,
-                this_ref_str,
-            )
-
+    def _build(self, this_ref_str, targets):
         # what needs building
         for evt in build.do_build(self.docker_client, this_ref_str, targets):
             yield evt
@@ -55,8 +26,9 @@ class Shipwright(object):
         # now that we're built and tagged all the images.
         # (either during the process of building or forwarding the tag)
         # tag all containers with the human readable tags.
-        for tag in self.source_control.default_tags() + self.tags:
-            for image in all_images:
+        tags = self.source_control.default_tags() + self.tags + [this_ref_str]
+        for image in targets:
+            for tag in tags:
                 yield docker.tag_container(
                     self.docker_client,
                     image,
@@ -68,19 +40,19 @@ class Shipwright(object):
         Pushes the latest images to the repository.
         """
         tree = dependencies.eval(specifiers, self.targets())
+        targets = dependencies.brood(tree)
+        this_ref_str = self.source_control.this_ref_str()
 
         if build:
-            info = self._get_build_info(tree)
-            for evt in self.build_tree(tree, info):
+            for evt in self.build_tree(this_ref_str, targets):
                 yield evt
-            tree = dependencies.make_tree(info['all_images'])
 
-        tags = self.source_control.default_tags() + self.tags
+        this_ref_str = self.source_control.this_ref_str()
+        tags = self.source_control.default_tags() + self.tags + [this_ref_str]
         names_and_tags = []
-        for dep in dependencies.brood(tree):
-            names_and_tags.append((dep.name, dep.last_built_ref))
+        for image in targets:
             for tag in tags:
-                names_and_tags.append((dep.name, tag))
+                names_and_tags.append((image.name, tag))
 
         for evt in push.do_push(self.docker_client, names_and_tags):
             yield evt

--- a/shipwright/docker.py
+++ b/shipwright/docker.py
@@ -28,17 +28,13 @@ def last_built_from_docker(client, name):
     return list([x for i in images for x in key_from_image_info(i)])
 
 
-def tags_from_containers(client, containers):
-    return [last_built_from_docker(client, c.name) for c in containers]
-
-
 def encode_tag(tag):
     return tag.replace('/', '-')
 
 
 def tag_container(client, container, new_ref):
     tag = encode_tag(new_ref)
-    image = container.name + ':' + container.last_built_ref
+    image = container.name + ':' + container.ref
     evt = {
         'event': 'tag',
         'container': container,


### PR DESCRIPTION
Rather than using "build_rels" which don't really exist in git define:

* A Dockerfile in a directory with SCM changes needs building.
* A Dockerfile with dependants that need building needs building.

Thus, the most recent commit of a Dockerfile directory and the directories of it's parents defines the most recent commit that needs building.

This is simpler, does not need to grab all the commits in the repo, and crucially **allows pulling images before building them** in a future change.