### PR TITLE
Add flag to build from working tree, even when uncommitted and untracked changes exist

### DIFF
--- a/shipwright/base.py
+++ b/shipwright/base.py
@@ -2,6 +2,16 @@ from __future__ import absolute_import
 
 from . import build, dependencies, docker, push
 
+_DIRTY_ERROR = {
+    'error': True,
+    'event': 'build_msg',
+    'errorDetail': {
+        'message': 'Aborting build, due to uncommitted changes.'
+        ' If you are not ready to commit these changes, re-run'
+        ' with the --dirty flag.',
+    },
+}
+
 
 class Shipwright(object):
     def __init__(self, source_control, docker_client, tags):
@@ -15,6 +25,8 @@ class Shipwright(object):
     def build(self, build_targets):
         targets = dependencies.eval(build_targets, self.targets())
         this_ref_str = self.source_control.this_ref_str()
+        if '-dirty-' in this_ref_str and not build_targets['dirty']:
+            return [_DIRTY_ERROR]
         return self._build(this_ref_str, targets)
 
     def _build(self, this_ref_str, targets):

--- a/shipwright/cli.py
+++ b/shipwright/cli.py
@@ -126,9 +126,15 @@ def argparser():
         help='extra tags to apply to the images',
     )
 
-    subparsers.add_parser(
+    build = subparsers.add_parser(
         'build', help='builds images', parents=[common],
     )
+    build.add_argument(
+        '--dirty',
+        help='Build working tree, including uncommited and untracked changes',
+        action='store_true',
+    )
+
     push = subparsers.add_parser(
         'push', help='pushes built images', parents=[common],
     )
@@ -151,6 +157,7 @@ def old_style_arg_dict(namespace):
         '--exclude': _flatten(ns.exclude),
         '--help': False,
         '--no-build': getattr(ns, 'no_build', False),
+        '--dirty': getattr(ns, 'dirty', False),
         '--upto': _flatten(ns.upto),
         '--x-assert-hostname': ns.x_assert_hostname,
         '-H': ns.docker_host,
@@ -208,6 +215,7 @@ def process_arguments(path, arguments, client_cfg, environ):
         'dependents': arguments['--dependents'],
         'exclude': arguments['--exclude'],
         'upto': arguments['--upto'],
+        'dirty': arguments['--dirty'],
     }
 
     no_build = False

--- a/shipwright/source_control.py
+++ b/shipwright/source_control.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import binascii
+import hashlib
+import os.path
 from collections import namedtuple
 
 import git
@@ -51,6 +54,31 @@ def _hexsha(ref):
     if ref is not None:
         return ref.hexsha[:12]
 
+def _hash_blob(blob):
+    if blob.hexsha != blob.NULL_HEX_SHA:
+        return blob.hexsha
+    else:
+        return blob.repo.git.hash_object(blob.abspath)
+
+def _dirty_suffix(repo, base_paths = ['.']):
+    abspath = lambda path: os.path.abspath(os.path.join(repo.working_dir, path))
+    hash_blobs = lambda blobs: [(b.path, _hash_blob(b)) for b in blobs if b]
+    in_paths = lambda path: any(abspath(path).startswith(abspath(base_path) + os.sep) for base_path in base_paths)
+
+    diff = repo.head.commit.diff(None)
+    a_hashes = hash_blobs(map(lambda d: d.a_blob, diff))
+    b_hashes = hash_blobs(map(lambda d: d.b_blob, diff))
+    untracked_hashes = [(path, repo.git.hash_object(path))
+                        for path in repo.untracked_files]
+    hashes = sorted(a_hashes) + sorted(b_hashes + untracked_hashes)
+    filtered_hashes = [(path, hash_) for path, hash_ in hashes if in_paths(path)]
+
+    if not filtered_hashes:
+        return ''
+    digest = hashlib.sha256()
+    for path, hash_ in filtered_hashes:
+        digest.update(path.encode('utf-8') + b'\0' + hash_.encode('utf-8'))
+    return '-dirty-' + binascii.hexlify(digest.digest())[:12].decode("utf-8")
 
 class GitSourceControl(object):
     def __init__(self, path, namespace, name_map):
@@ -68,7 +96,7 @@ class GitSourceControl(object):
         return [branch]
 
     def this_ref_str(self):
-        return _hexsha(self._repo.commit())
+        return _hexsha(self._repo.commit()) + _dirty_suffix(self._repo)
 
     def targets(self):
         repo = self._repo
@@ -84,7 +112,7 @@ class GitSourceControl(object):
 
         for c in images:
             paths = [p.dir_path for p in _image_parents(c_index, c)]
-            ref = _hexsha(_last_commit(repo, paths))
+            ref = _hexsha(_last_commit(repo, paths)) + _dirty_suffix(repo, paths)
             targets.append(Target(image=c, ref=ref, children=None))
 
         return targets

--- a/shipwright/source_control.py
+++ b/shipwright/source_control.py
@@ -54,16 +54,24 @@ def _hexsha(ref):
     if ref is not None:
         return ref.hexsha[:12]
 
+
 def _hash_blob(blob):
     if blob.hexsha != blob.NULL_HEX_SHA:
         return blob.hexsha
     else:
         return blob.repo.git.hash_object(blob.abspath)
 
-def _dirty_suffix(repo, base_paths = ['.']):
-    abspath = lambda path: os.path.abspath(os.path.join(repo.working_dir, path))
-    hash_blobs = lambda blobs: [(b.path, _hash_blob(b)) for b in blobs if b]
-    in_paths = lambda path: any(abspath(path).startswith(abspath(base_path) + os.sep) for base_path in base_paths)
+
+def _dirty_suffix(repo, base_paths=['.']):
+    def abspath(path):
+        return os.path.abspath(os.path.join(repo.working_dir, path))
+
+    def hash_blobs(blobs):
+        return [(b.path, _hash_blob(b)) for b in blobs if b]
+
+    def in_paths(path):
+        return any(abspath(path).startswith(abspath(base_path) + os.sep)
+                   for base_path in base_paths)
 
     diff = repo.head.commit.diff(None)
     a_hashes = hash_blobs(map(lambda d: d.a_blob, diff))
@@ -71,14 +79,15 @@ def _dirty_suffix(repo, base_paths = ['.']):
     untracked_hashes = [(path, repo.git.hash_object(path))
                         for path in repo.untracked_files]
     hashes = sorted(a_hashes) + sorted(b_hashes + untracked_hashes)
-    filtered_hashes = [(path, hash_) for path, hash_ in hashes if in_paths(path)]
+    filtered_hashes = [(path, h) for path, h in hashes if in_paths(path)]
 
     if not filtered_hashes:
         return ''
     digest = hashlib.sha256()
-    for path, hash_ in filtered_hashes:
-        digest.update(path.encode('utf-8') + b'\0' + hash_.encode('utf-8'))
-    return '-dirty-' + binascii.hexlify(digest.digest())[:12].decode("utf-8")
+    for path, h in filtered_hashes:
+        digest.update(path.encode('utf-8') + b'\0' + h.encode('utf-8'))
+    return '-dirty-' + binascii.hexlify(digest.digest())[:12].decode('utf-8')
+
 
 class GitSourceControl(object):
     def __init__(self, path, namespace, name_map):
@@ -112,7 +121,8 @@ class GitSourceControl(object):
 
         for c in images:
             paths = [p.dir_path for p in _image_parents(c_index, c)]
-            ref = _hexsha(_last_commit(repo, paths)) + _dirty_suffix(repo, paths)
+            ref = (_hexsha(_last_commit(repo, paths)) +
+                   _dirty_suffix(repo, paths))
             targets.append(Target(image=c, ref=ref, children=None))
 
         return targets

--- a/tests/integration/test_git.py
+++ b/tests/integration/test_git.py
@@ -29,6 +29,7 @@ def test_default_tags_works_with_detached_head(tmpdir):
 
     assert scm.default_tags() == []
 
+
 def test_dirty_tags(tmpdir):
     tmp = tmpdir.join('shipwright-sample')
     path = str(tmp)
@@ -44,44 +45,37 @@ def test_dirty_tags(tmpdir):
         name_map={},
     )
 
-    refs = lambda: {target.image.name: target.ref for target in scm.targets()}
+    def refs():
+        return {target.image.name: target.ref for target in scm.targets()}
     clean_refs = refs()
     clean_ref_str = scm.this_ref_str()
 
-    tmp.join('shared/base.txt').write('Hi mum') # Untracked
+    tmp.join('shared/base.txt').write('Hi mum')  # Untracked
 
-    dirty_refs = refs()
-
-    assert dirty_refs['shipwright/base'] == clean_refs['shipwright/base']
-    assert dirty_refs['shipwright/shared'] != clean_refs['shipwright/shared']
-    assert dirty_refs['shipwright/service1'] != clean_refs['shipwright/service1']
-    assert '-dirty-' in dirty_refs['shipwright/service1']
-    assert '-dirty-' in dirty_refs['shipwright/shared']
+    assert refs()['shipwright/base'] == clean_refs['shipwright/base']
+    assert refs()['shipwright/shared'] != clean_refs['shipwright/shared']
+    assert refs()['shipwright/service1'] != clean_refs['shipwright/service1']
+    assert '-dirty-' in refs()['shipwright/service1']
+    assert '-dirty-' in refs()['shipwright/shared']
     assert clean_ref_str != scm.this_ref_str()
 
-    repo.index.add(['shared/base.txt']) # Tracked
+    repo.index.add(['shared/base.txt'])  # Tracked
 
-    dirty_refs = refs()
-
-    assert dirty_refs['shipwright/base'] == clean_refs['shipwright/base']
-    assert dirty_refs['shipwright/shared'] != clean_refs['shipwright/shared']
-    assert dirty_refs['shipwright/service1'] != clean_refs['shipwright/service1']
-    assert '-dirty-' in dirty_refs['shipwright/service1']
-    assert '-dirty-' in dirty_refs['shipwright/shared']
+    assert refs()['shipwright/base'] == clean_refs['shipwright/base']
+    assert refs()['shipwright/shared'] != clean_refs['shipwright/shared']
+    assert refs()['shipwright/service1'] != clean_refs['shipwright/service1']
+    assert '-dirty-' in refs()['shipwright/service1']
+    assert '-dirty-' in refs()['shipwright/shared']
     assert clean_ref_str != scm.this_ref_str()
 
-    tmp.join('base/base.txt').write('Hi again') # Modified, but not added to index
-    dirty_refs = refs()
-    assert dirty_refs['shipwright/base'] != clean_refs['shipwright/base']
+    tmp.join('base/base.txt').write('Hi again')  # Modified, not added to index
+    assert refs()['shipwright/base'] != clean_refs['shipwright/base']
 
-    repo.index.add(['base/base.txt']) # Modified version added to index
-    dirty_refs = refs()
-    assert dirty_refs['shipwright/base'] != clean_refs['shipwright/base']
+    repo.index.add(['base/base.txt'])  # Modified version added to index
+    assert refs()['shipwright/base'] != clean_refs['shipwright/base']
 
-    tmp.join('base/base.txt').remove() # Deleted, but not removed from index
-    dirty_refs = refs()
-    assert dirty_refs['shipwright/base'] != clean_refs['shipwright/base']
+    tmp.join('base/base.txt').remove()  # Deleted, but not removed from index
+    assert refs()['shipwright/base'] != clean_refs['shipwright/base']
 
-    repo.index.remove(['base/base.txt']) # Remove from index
-    dirty_refs = refs()
-    assert dirty_refs['shipwright/base'] != clean_refs['shipwright/base']
+    repo.index.remove(['base/base.txt'])  # Remove from index
+    assert refs()['shipwright/base'] != clean_refs['shipwright/base']

--- a/tests/integration/test_git.py
+++ b/tests/integration/test_git.py
@@ -28,3 +28,60 @@ def test_default_tags_works_with_detached_head(tmpdir):
     )
 
     assert scm.default_tags() == []
+
+def test_dirty_tags(tmpdir):
+    tmp = tmpdir.join('shipwright-sample')
+    path = str(tmp)
+    source = pkg_resources.resource_filename(
+        __name__,
+        'examples/shipwright-sample',
+    )
+    repo = create_repo(path, source)
+
+    scm = source_control.GitSourceControl(
+        path=path,
+        namespace='shipwright',
+        name_map={},
+    )
+
+    refs = lambda: {target.image.name: target.ref for target in scm.targets()}
+    clean_refs = refs()
+    clean_ref_str = scm.this_ref_str()
+
+    tmp.join('shared/base.txt').write('Hi mum') # Untracked
+
+    dirty_refs = refs()
+
+    assert dirty_refs['shipwright/base'] == clean_refs['shipwright/base']
+    assert dirty_refs['shipwright/shared'] != clean_refs['shipwright/shared']
+    assert dirty_refs['shipwright/service1'] != clean_refs['shipwright/service1']
+    assert '-dirty-' in dirty_refs['shipwright/service1']
+    assert '-dirty-' in dirty_refs['shipwright/shared']
+    assert clean_ref_str != scm.this_ref_str()
+
+    repo.index.add(['shared/base.txt']) # Tracked
+
+    dirty_refs = refs()
+
+    assert dirty_refs['shipwright/base'] == clean_refs['shipwright/base']
+    assert dirty_refs['shipwright/shared'] != clean_refs['shipwright/shared']
+    assert dirty_refs['shipwright/service1'] != clean_refs['shipwright/service1']
+    assert '-dirty-' in dirty_refs['shipwright/service1']
+    assert '-dirty-' in dirty_refs['shipwright/shared']
+    assert clean_ref_str != scm.this_ref_str()
+
+    tmp.join('base/base.txt').write('Hi again') # Modified, but not added to index
+    dirty_refs = refs()
+    assert dirty_refs['shipwright/base'] != clean_refs['shipwright/base']
+
+    repo.index.add(['base/base.txt']) # Modified version added to index
+    dirty_refs = refs()
+    assert dirty_refs['shipwright/base'] != clean_refs['shipwright/base']
+
+    tmp.join('base/base.txt').remove() # Deleted, but not removed from index
+    dirty_refs = refs()
+    assert dirty_refs['shipwright/base'] != clean_refs['shipwright/base']
+
+    repo.index.remove(['base/base.txt']) # Remove from index
+    dirty_refs = refs()
+    assert dirty_refs['shipwright/base'] != clean_refs['shipwright/base']

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -14,6 +14,7 @@ def get_defaults():
         '--exclude': [],
         '--help': False,
         '--no-build': False,
+        '--dirty': False,
         '--upto': [],
         '--x-assert-hostname': False,
         '-H': None,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,7 @@ def get_defaults():
         '--exclude': [],
         '--help': False,
         '--no-build': False,
+        '--dirty': False,
         '--upto': [],
         '--x-assert-hostname': False,
         '-H': None,
@@ -89,6 +90,7 @@ def test_args():
         '--exclude': [],
         '--help': False,
         '--no-build': False,
+        '--dirty': False,
         '--upto': [],
         '--x-assert-hostname': True,
         '-H': None,
@@ -103,7 +105,7 @@ def test_args_2():
     args = [
         '--account=x', '--x-assert-hostname', 'build',
         '-d', 'foo', 'bar',
-        '-t', 'foo',
+        '-t', 'foo', '--dirty',
     ]
     parser = cli.argparser()
     arguments = cli.old_style_arg_dict(parser.parse_args(args))
@@ -116,6 +118,7 @@ def test_args_2():
         '--exclude': [],
         '--help': False,
         '--no-build': False,
+        '--dirty': True,
         '--upto': [],
         '--x-assert-hostname': True,
         '-H': None,
@@ -139,6 +142,7 @@ def test_args_base():
         '--exclude': [],
         '--help': False,
         '--no-build': False,
+        '--dirty': False,
         '--upto': [],
         '--x-assert-hostname': False,
         '-H': None,


### PR DESCRIPTION
This pull request changes the behaviour of Shipwright, in the presence of uncommitted or untracked changes. The default is now for it to refuse to build, but show the user an error message informing them of the new `--dirty` flag. With the new flag on, Shipwright will build, and give images a tag that shows it's a dirty build, including a hash of the diff from HEAD. This implements #42. 

This should mean that any difference between the file system and HEAD flags as dirty - this seemed best, since Docker only cares about the file system, so this minimises the possibility for surprise.

As suggested in the discussion on #42, hashes are filtered by path, so it should only rebuild images whose dependencies have changed.