### PR TITLE
Fix issue when running dirty builds with Dockerfiles in new directories

### DIFF
--- a/shipwright/source_control.py
+++ b/shipwright/source_control.py
@@ -53,6 +53,8 @@ def _image_parents(index, image):
 def _hexsha(ref):
     if ref is not None:
         return ref.hexsha[:12]
+    else:
+        return 'g' * 12
 
 
 def _hash_blob(blob):

--- a/tests/integration/test_git.py
+++ b/tests/integration/test_git.py
@@ -75,6 +75,49 @@ def test_dirty_tags_untracked(tmpdir):
     assert new_ref_str == dirty_tag
 
 
+def test_dirty_tags_new_dir(tmpdir):
+    tmp = tmpdir.join('shipwright-sample')
+    path = str(tmp)
+    source = pkg_resources.resource_filename(
+        __name__,
+        'examples/shipwright-sample',
+    )
+    repo = create_repo(path, source)
+
+    scm = source_control.GitSourceControl(
+        path=path,
+        namespace='shipwright',
+        name_map={},
+    )
+    assert not scm.is_dirty()
+
+    old_ref_str = scm.this_ref_str()
+    tag = repo.head.ref.commit.hexsha[:12]
+
+    tmp.join('service2').mkdir()
+    tmp.join('service2/Dockerfile').write('FROM busybox\n')
+    assert scm.is_dirty()
+
+    new_refs = _refs(scm.targets())
+    new_ref_str = scm.this_ref_str()
+
+    dirty_suffix = '-dirty-f2f0df80ff0f'
+    service2_tag = 'g' * 12 + dirty_suffix
+    assert new_refs['shipwright/base'] == tag
+    assert new_refs['shipwright/shared'] == tag
+    assert new_refs['shipwright/service1'] == tag
+    assert new_refs['shipwright/service2'] == service2_tag
+
+    assert new_refs == {
+        'shipwright/base': tag,
+        'shipwright/service1': tag,
+        'shipwright/shared': tag,
+        'shipwright/service2': service2_tag,
+    }
+    assert old_ref_str == tag
+    assert new_ref_str == tag + dirty_suffix
+
+
 def test_dirty_tags_tracked(tmpdir):
     tmp = tmpdir.join('shipwright-sample')
     path = str(tmp)


### PR DESCRIPTION
If you add a new directory, containing new Dockerfiles, then `--dirty` builds fail because there are no commits containing the new directory. This change provides a default commit of `000000000000` for directories that have never appeared in a commit.